### PR TITLE
日時のフォームをtext_fieldから、date_select,time_selectに変更

### DIFF
--- a/app/assets/stylesheets/events_index.scss
+++ b/app/assets/stylesheets/events_index.scss
@@ -49,12 +49,12 @@
     flex-wrap: wrap;
     justify-content: center;
     @media screen and (min-width:768px) and (max-width:1024px) {
-      // justify-content: space-between;
+      justify-content: space-between;
       max-width: 768px;
       margin: 0 auto;
     }
     @media screen and (min-width: 1024px) {
-      // justify-content: space-between;
+      justify-content: space-between;
       max-width: 960px;
       margin: 0 auto;
     }

--- a/app/assets/stylesheets/events_new.scss
+++ b/app/assets/stylesheets/events_new.scss
@@ -26,13 +26,15 @@
     line-height: 1.5;
     outline: 0;
   }
-
-  #event_date {
+  .form_border_bottom {
     width: 100%;
-    border: none;
     border-bottom: 1px solid #212529;
-    display: block;
-    width: 100%;
+    padding: 0.375rem 0.75rem;
+  }
+
+  #event_date_1i,#event_date_2i,#event_date_3i {
+    width: 25%;
+    border: none;
     height: calc(1.5em + 0.75rem + 2px);
     padding: 0.375rem 0.75rem;
     font-size: 1rem;
@@ -40,6 +42,18 @@
     line-height: 1.5;
     outline: 0;
   }
+
+  #event_open_time_4i, #event_open_time_5i,#event_end_time_4i, #event_end_time_5i {
+    width: 15%;
+    border: none;
+    height: calc(1.5em + 0.75rem + 2px);
+    padding: 0.375rem 0.75rem;
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 1.5;
+    outline: 0;
+  }
+
 
   #event_time {
     width: 100%;

--- a/app/assets/stylesheets/users_show.scss
+++ b/app/assets/stylesheets/users_show.scss
@@ -114,9 +114,11 @@
         font-size: 1.5rem;
         font-weight: bold;
         margin: 1rem 0;
+        word-wrap: break-word;
       }
       &--others {
         margin-bottom: 1rem;
+        word-wrap: break-word;
       }
     }
     &__lower {

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -53,7 +53,7 @@ class EventsController < ApplicationController
   end
 
   def event_params
-    params.require(:event).permit(:name, :place, :date, :time, :image, :description).merge(owner: current_user.id)
+    params.require(:event).permit(:id, :name, :place, :date, :open_time, :end_time ,:image, :description).merge(owner: current_user.id)
   end
 
 end

--- a/app/views/events/new.html.haml
+++ b/app/views/events/new.html.haml
@@ -21,11 +21,15 @@
       .field
         = f.label :開催日
         %br/
-        = f.text_field :date, autofocus: true, autocomplete: "date", placeholder: "20XX年01月23日"
+        .form_border_bottom
+          = f.date_select :date, autofocus: true, autocomplete: "date"
       .field
-        = f.label :開催時間
+        = f.label :時間
         %br/
-        = f.text_field :time, autofocus: true, autocomplete: "time", placeholder: "13:00 ~ 15:00"
+        .form_border_bottom
+          = f.time_select :open_time
+          〜
+          = f.time_select :end_time
       .field
         = f.label :詳細
         %br/

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -13,11 +13,13 @@
             %tr
               %th 日にち
               %td
-                = @event.date
+                = @event.date.strftime("%Y年%m月%d日")
             %tr
               %th 時間
               %td
-                = @event.time
+                = "#{@event.open_time}".slice(11..15)
+                〜
+                = "#{@event.end_time}".slice(11..15)
             %tr
               %th 場所
               %td
@@ -45,7 +47,7 @@
             .user_card__icon
               = image_tag user.image.url, class: "user_card__icon--content"
             .user_card__name
-              = user.name
+              = user.name.truncate(12)
             .user_card__request
               - if user.id == current_user.id
                 = link_to "あなたです", user_path(user), class: "user_card__request--done_btn"

--- a/app/views/rooms/show.html.haml
+++ b/app/views/rooms/show.html.haml
@@ -10,7 +10,7 @@
       - else
         .other_message
           %span.other_content
-            = message.content
+            = simple_format(message.content)
   .room_footer
     = form_with(model: @message, url: messages_path, local: true) do |f|
       = f.hidden_field :room_id, value: @room.id

--- a/app/views/shared/_event_cards.html.haml
+++ b/app/views/shared/_event_cards.html.haml
@@ -9,10 +9,12 @@
           = event.name.truncate(19)
         .event_date
           日にち：
-          = event.date.truncate(17)
+          = event.date.strftime("%Y年%m月%d日")
         .event_time
           時間　：
-          = event.time.truncate(17)
+          = "#{event.open_time}".slice(11..15)
+          〜
+          = "#{event.end_time}".slice(11..15)
         .event_place
           場所　：
           = event.place.truncate(15)

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,7 @@ module StConnect
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
     config.i18n.default_locale = :ja
+    config.time_zone = 'Tokyo'
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/db/migrate/20200223065249_create_events.rb
+++ b/db/migrate/20200223065249_create_events.rb
@@ -2,10 +2,11 @@ class CreateEvents < ActiveRecord::Migration[5.2]
   def change
     create_table :events do |t|
       t.string :name, null: false
-      t.string :date, null: false
+      t.date :date, null: false
       t.text :image
       t.string :place, null: false
-      t.string :time, null: false
+      t.time :open_time, null: false
+      t.time :end_time
       t.integer :owner, null: false
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -23,11 +23,12 @@ ActiveRecord::Schema.define(version: 2020_02_28_022106) do
 
   create_table "events", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
-    t.string "date", default: ""
+    t.date "date", null: false
     t.text "image"
-    t.string "place", default: ""
-    t.string "time", default: ""
-    t.integer "owner"
+    t.string "place", null: false
+    t.time "open_time", null: false
+    t.time "end_time"
+    t.integer "owner", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "description", null: false


### PR DESCRIPTION
# WHAT
・イベント作成ページの日時のフォームをtext_fieldからdate_select, time_selectに変更
・eventテーブルのdateのカラム型をdateに変更
・eventテーブルのtimeを削除、open_time, end_timeのカラムをtime型で作成
※イベント作成画面のレスポンシブ対応必要

# WHY
・UXをあげるため