### PR TITLE
ユーザー新規登録ページ/写真投稿フォームのプレビュー機能実装

### DIFF
--- a/app/assets/javascripts/image_form.js
+++ b/app/assets/javascripts/image_form.js
@@ -21,3 +21,30 @@ $(function(){
     reader.readAsDataURL(file);
   });
 });
+
+
+// ユーザー新規登録
+
+$(function(){
+  $fileField = $('#regitration_file')
+ 
+  // 選択された画像を取得し表示
+  $($fileField).on('change', $fileField, function(e) {
+    file = e.target.files[0]
+    reader = new FileReader(),
+    $preview = $("#regitration_img_field");
+ 
+    reader.onload = (function(file) {
+      return function(e) {
+        $preview.empty();
+        $preview.append($('<img>').attr({
+          src: e.target.result,
+          width: "100%",
+          class: "regitration_preview",
+          title: file.name
+        }));
+      };
+    })(file);
+    reader.readAsDataURL(file);
+  });
+});

--- a/app/assets/stylesheets/events_show.scss
+++ b/app/assets/stylesheets/events_show.scss
@@ -55,6 +55,10 @@
         }
       }
     }
+    .owner_link {
+      text-decoration: none;
+      color: #222;
+    }
   }
   
     .admin_btn {

--- a/app/assets/stylesheets/image_form.scss
+++ b/app/assets/stylesheets/image_form.scss
@@ -18,7 +18,10 @@
   box-sizing: border-box;
   transition: 0.3s ease-out;
   text-align: center;
-
+}
+.preview {
+  object-fit: cover;
+  height: 250px;
 }
 
 #img_field i {
@@ -49,4 +52,61 @@
   display: block;
   color: #fff;
   text-align: center;
+}
+
+#regitration_img_field {
+  font-size: 15px;
+  margin-top: 10px;
+  padding: 5px 8px;
+  border: solid 1px #eee;
+  color: #666;
+  position: relative;
+  padding: 0;
+  border-radius: 50%;
+  cursor: pointer;
+  width: 200px;
+  height: 200px;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: contain;
+  background-color: #fff;
+  overflow: hidden;
+  box-sizing: border-box;
+  transition: 0.3s ease-out;
+  text-align: center;
+}
+
+#regitration_img_field i {
+  font-size: 100px;
+  color: #aaa;
+  line-height: 200px;
+  transition: 0.3s ease-out;
+  text-align: center;
+}
+
+#regitration_img_field i.add {
+  display: none;
+  font-size: 50px;
+  position: absolute;
+  top: -90px;
+  right: 15px;
+  text-align: center;
+}
+
+#regitration_img_field:hover {
+  background-color: #aaa;
+  transition: 0.3s ease-out;
+  opacity: 0.9;
+}
+
+#regitration_img_field:hover i {
+  transition: 0.3s ease-out;
+  display: block;
+  color: #fff;
+  text-align: center;
+}
+
+.regitration_preview {
+  object-fit: cover;
+  height: 200px;
 }

--- a/app/assets/stylesheets/users_show.scss
+++ b/app/assets/stylesheets/users_show.scss
@@ -109,7 +109,7 @@
     }
   }
     &__text_box {
-      padding-left: 1.5rem;
+      padding: 1rem;
       &--name {
         font-size: 1.5rem;
         font-weight: bold;

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -21,6 +21,7 @@ class EventsController < ApplicationController
   def show
     @users = @event.users
     @event_user = EventUser.where(event_id: @event.id, user_id: current_user.id)[0]
+    @owner = User.find_by(id: @event.owner)
   end
   
   def edit

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -6,8 +6,20 @@
       = render "devise/shared/error_messages", resource: resource
       .field
         = f.label :プロフィール写真
+        .field.image
+          -# = icon('fas', 'camera')
+          -# = f.label 'サムネイル（スクリーンショットなど）'
+          -# \// id "file"で、fileとdivを紐付けクリック時に連動
+          #regitration_img_field{:onclick => "$('#regitration_file').click()"}
+            -# \// 画像があるときは画像を表示する
+            - if @user.image.url.present?
+              = image_tag(@user.image.url)
+            - else
+              = icon('fas', 'camera')
+          = f.file_field :image, class: "regitration_image", style: "display:none;", id: "regitration_file"
+
         %br/
-        = f.file_field :image, autofocus: true, autocomplete: "name", placeholder: "田中ユウキ"
+        -# = f.file_field :image, autofocus: true, autocomplete: "name", placeholder: "田中ユウキ"
       .field
         = f.label :ユーザーネーム
         %br/

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -28,6 +28,10 @@
               %th 詳細
               %td
                 = simple_format(@event.description)
+            %tr
+              %th 主催者
+              %td
+                = link_to @owner.name, user_path(@owner.id), class: "owner_link"
 
     - if user_signed_in? && current_user.id == @event.owner
       = link_to "イベントを編集する", edit_event_path(@event.id), class: "admin_btn"


### PR DESCRIPTION
# WHAT
・ユーザー新規登録ページの写真投稿フォームにおいて、写真のプレビュー機能を実装
・イベント登録とは別のclassを作成し、円い投稿フォームとした

# WHY
・UXをあげるため

[![Image from Gyazo](https://i.gyazo.com/c5890b088a37514a78db5f23926b1429.gif)](https://gyazo.com/c5890b088a37514a78db5f23926b1429)