### PR TITLE
リクエスト通知機能の実装

### DIFF
--- a/app/assets/javascripts/notifications.js
+++ b/app/assets/javascripts/notifications.js
@@ -1,0 +1,2 @@
+// Place all the behaviors and hooks related to the matching controller here.
+// All this logic will automatically be available in application.js.

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,3 +11,5 @@
 @import "events_show";
 @import "rooms_show";
 @import "image_form";
+@import "notifications";
+@import "notifications_index";

--- a/app/assets/stylesheets/events_index.scss
+++ b/app/assets/stylesheets/events_index.scss
@@ -97,7 +97,7 @@
           height: 230px;
         }
         @media screen and (min-width: 1024px) {
-          width: 469px;
+          width: 468px;
           height: 329px;
         }
         }

--- a/app/assets/stylesheets/notifications.scss
+++ b/app/assets/stylesheets/notifications.scss
@@ -1,0 +1,17 @@
+.bell_icon {
+  text-decoration: none;
+  color: black;
+}
+
+.n-circle {
+  position: absolute;
+  padding-left: 0.5rem;
+  padding-top: 0rem;
+  color:  #ff6b8d ;
+}
+
+@-webkit-keyframes AnimationName {
+  0%{background-position:0% 50%}
+  50%{background-position:100% 50%}
+  100%{background-position:0% 50%}
+}

--- a/app/assets/stylesheets/notifications_index.scss
+++ b/app/assets/stylesheets/notifications_index.scss
@@ -1,0 +1,55 @@
+.notifications {
+  max-width: 960px;
+  margin: 0 auto;
+  border-bottom: 1px solid #eee;
+  display: flex;
+  justify-content: space-between;
+  position: relative;
+  padding: 0.5rem;
+  @media screen and (min-width:425px) {
+    padding: 0.5rem 1rem;
+  }
+  &__img {
+    &--content {
+      width: 60px;
+      height: 60px;
+      border-radius: 50%;
+      @media screen and (min-width:1024px) {
+        width: 100px;
+        height: 100px;
+      }
+    }
+  }
+  &__text {
+    position: absolute;
+    left: 70px;
+    top: 30%;
+    font-size: 0.5rem;
+    @media screen and (min-width:425px) and (max-width:1024px){
+      left: 90px;
+      font-size: 0.8rem;
+      top: 25%;
+    }
+    @media screen and (min-width:1024px) {
+      left: 150px;
+      font-size: 1rem;
+    }
+    &--content {
+      text-decoration: none;
+      font-weight: bold;
+      color: #222;
+    }
+  }
+  &__right {
+    position: absolute;
+    bottom: 0.3rem;
+    right: 1rem;
+    font-size: 0.5rem;
+    @media screen and (min-width:768px) {
+      font-size: 0.8rem;
+    }
+    @media screen and (min-width:1024px) {
+      font-size: 1rem;
+    }
+  }
+}

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,0 +1,8 @@
+class NotificationsController < ApplicationController
+  def index
+    @notifications = current_user.passive_notifications
+    @notifications.where(checked: false).each do |notification|
+      notification.update_attributes(checked: true)
+    end
+  end
+end

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -4,6 +4,8 @@ class RelationshipsController < ApplicationController
   def create
     user = User.find(params[:relationship][:following_id])
     following = current_user.follow(user)
+    user.create_notification_follow!(current_user)
+    
     if following.save
       flash[:success] = 'ユーザーをフォローしました'
       redirect_to user

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -1,0 +1,5 @@
+module NotificationsHelper
+  def unchecked_notifications
+    @notifications = current_user.passive_notifications.where(checked: false)
+  end
+end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,5 @@
+class Notification < ApplicationRecord
+  default_scope -> { order(created_at: :desc)}
+  belongs_to :visitor, class_name: 'User', foreign_key: 'visitor_id'
+  belongs_to :visited, class_name: 'User', foreign_key: 'visited_id'
+end

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -5,9 +5,10 @@
       一緒にプレイできるチームメイトを探してみよう！
       %br
       STREET CONNECTとは？
-    -# .top_message__discription STREET CONNECTとは？
   .content_title
     イベント一覧
+  .search_form
+    = link_to "検索", "#"
   %ul.cards_box
     = render 'shared/event_cards'
     = paginate(@events)

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -39,7 +39,7 @@
     - else
       -if user_signed_in? && @event_user.nil?
         = link_to "イベントに参加する", join_event_path(@event.id), method: :post, class: 'join_btn'
-      - elsif user_signed_in? && @event_user.nil
+      - elsif user_signed_in?
         = link_to "参加をやめる", unjoin_event_path(@event.id), method: :delete, class: "done_btn"
       - else
         = link_to "イベントに参加する場合はログインをしてください", user_session_path, class: "join_btn"

--- a/app/views/notifications/_notification.html.haml
+++ b/app/views/notifications/_notification.html.haml
@@ -1,0 +1,17 @@
+- visitor = notification.visitor
+- visited = notification.visited
+
+.form_inline
+  span
+    = link_to user_path(visitor) do
+      = image_tag visitor.image.url
+      strong
+        = visitor.name
+      = 'さんが'
+
+  - case notification.action
+  - when 'follow' then
+    = 'あなたをフォローしました'
+    
+.text_right
+  = time_ago_in_words(notification.created_at).upcase

--- a/app/views/notifications/index.html.haml
+++ b/app/views/notifications/index.html.haml
@@ -1,0 +1,26 @@
+= render 'shared/header'
+.content_box
+  .content_title リクエスト通知一覧
+  - if @notifications.exists?
+    - @notifications.each do |notification|
+      - visitor = notification.visitor
+      - visited = notification.visited
+      .notifications
+        .notifications__left
+          %span.notifications__img
+            = link_to user_path(visitor) do
+              = image_tag visitor.image.url, class:"notifications__img--content"
+          %span.notifications__text
+            %p
+              = link_to visitor.name, user_path(visitor), class: "notifications__text--content"
+              が
+              %br
+              あなたにリクエストしました
+        .notifications__right
+          = time_ago_in_words(notification.created_at).upcase
+          
+  - else
+    .form_notifications
+      %p.form_notifications__nothing 通知はありません
+
+  = render 'shared/footer'

--- a/app/views/shared/_circle.html.haml
+++ b/app/views/shared/_circle.html.haml
@@ -1,0 +1,7 @@
+= link_to(notifications_path) do
+  - if unchecked_notifications.any?
+    %span.fa-stack
+      %i.far.fa-bell.fa-lg.fa-stack-2x{ style: "font-size: 1.5em;"} 
+      %i.fas.fa-circle.n-circle.fa-stack-1x
+  - else 
+    %i.far.fa-bell.fa-lg{ style: "font-size: 1.5em;" } 

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -1,4 +1,17 @@
 %header
-  = link_to "STREET CONNECT", root_path, class: 'header_logo'
-  - if user_signed_in?
-    = link_to "ログアウト", destroy_user_session_path, method: :delete
+  .header_left
+    = link_to "STREET CONNECT", root_path, class: 'header_logo'
+  .header_right
+    - if user_signed_in?
+      = link_to notifications_path do
+        - if unchecked_notifications.any?
+          %span.fa-stack
+            %i.far.fa-bell.fa-lg.fa-stack-2x.bell_icon
+            %i.fas.fa-circle.n-circle.fa-stack-1x
+        - else 
+          %i.far.fa-bell.fa-lg.bell_icon
+
+      = link_to "ログアウト", destroy_user_session_path, method: :delete
+    - else
+      = link_to "ログイン", new_user_session_path
+      = link_to "新規登録", new_user_registration_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,5 +20,5 @@ Rails.application.routes.draw do
   resources :relationships, only: [:create, :destroy]
   resources :rooms, only: [:index, :new, :create, :show, :update]
   resources :messages, only: [:index, :create]
-
+  resources :notifications, only: [:index]
 end

--- a/db/migrate/20200302040735_create_notifications.rb
+++ b/db/migrate/20200302040735_create_notifications.rb
@@ -1,0 +1,12 @@
+class CreateNotifications < ActiveRecord::Migration[5.2]
+  def change
+    create_table :notifications do |t|
+      t.integer :visitor_id, null: false
+      t.integer :visited_id, null: false
+      t.boolean :checked, default: false, null: false
+      t.timestamps
+    end
+    add_index :notifications, :visitor_id
+    add_index :notifications, :visited_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_28_022106) do
+ActiveRecord::Schema.define(version: 2020_03_02_040735) do
 
   create_table "event_users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "event_id"
@@ -26,7 +26,7 @@ ActiveRecord::Schema.define(version: 2020_02_28_022106) do
     t.date "date", null: false
     t.text "image"
     t.string "place", null: false
-    t.time "open_time", null: false
+    t.time "open_time"
     t.time "end_time"
     t.integer "owner", null: false
     t.datetime "created_at", null: false
@@ -42,6 +42,16 @@ ActiveRecord::Schema.define(version: 2020_02_28_022106) do
     t.datetime "updated_at", null: false
     t.index ["room_id"], name: "index_messages_on_room_id"
     t.index ["user_id"], name: "index_messages_on_user_id"
+  end
+
+  create_table "notifications", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "visitor_id", null: false
+    t.integer "visited_id", null: false
+    t.boolean "checked", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["visited_id"], name: "index_notifications_on_visited_id"
+    t.index ["visitor_id"], name: "index_notifications_on_visitor_id"
   end
 
   create_table "relationships", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class NotificationsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class NotificationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# WHAT
・未読のリクエストがあった場合に通知されるよう機能を実装
・notificationテーブルを作成し、リクエストがあった場合のみ通知がくる仕様
・非同期機能は無し
・未読の通知があると、ヘッダーのベルアイコンに丸の通知マークがつく

# WHY
・リクエストがきてもユーザーから確認をしに行かないとわからない仕様でUXが悪かったため