### PR TITLE
ユーザー情報編集画面のフォーム追加・CSS作成

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,3 +13,4 @@
 @import "image_form";
 @import "notifications";
 @import "notifications_index";
+@import "modules/flash";

--- a/app/assets/stylesheets/modules/flash.scss
+++ b/app/assets/stylesheets/modules/flash.scss
@@ -1,0 +1,13 @@
+.notification {
+  .notice {
+    background-color: #38AEF0;
+    color: #fff;
+    text-align: center;
+  }
+
+  .alert {
+    background-color: #F35500;
+    color: #fff;
+    text-align: center;
+  }
+}

--- a/app/assets/stylesheets/notifications.scss
+++ b/app/assets/stylesheets/notifications.scss
@@ -1,8 +1,9 @@
-.bell_icon {
+.fa-bell {
   font-size: 1.4rem;
   text-decoration: none;
   color: black;
-  margin: 0 1rem;
+  margin: 0.5rem 1rem 0 0;
+  position: relative;
 }
 
 .n-circle {

--- a/app/assets/stylesheets/notifications_index.scss
+++ b/app/assets/stylesheets/notifications_index.scss
@@ -14,6 +14,7 @@
       width: 60px;
       height: 60px;
       border-radius: 50%;
+      object-fit: cover;
       @media screen and (min-width:1024px) {
         width: 100px;
         height: 100px;

--- a/app/assets/stylesheets/users_form.scss
+++ b/app/assets/stylesheets/users_form.scss
@@ -85,6 +85,24 @@
         line-height: 1.5;
         outline: 0;
       }
+      .user_edit_img {
+        width: 200px;
+        height: 200px;
+        object-fit: cover;
+      }
+      #user_current_password {
+        width: 100%;
+        border: none;
+        border: 1px solid #969696;
+        display: block;
+        width: 100%;
+        height: calc(1.5em + 0.75rem + 2px);
+        padding: 0.375rem 0.75rem;
+        font-size: 1rem;
+        font-weight: 400;
+        line-height: 1.5;
+        outline: 0;
+      }
     }
     .actions {
       text-align: center;
@@ -94,6 +112,16 @@
         border-radius: 5px;
         font-weight: bold;
         cursor: pointer;
+        appearance: none;
+      }
+      input {
+        -webkit-appearance: none;
+        border: none;
+        padding: 10px;
+        font-weight: bold;
+        cursor: pointer;
+        appearance: none;
+        margin-top: 1rem;
       }
     }
     a {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,10 +2,10 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  has_many :evnet_users, foreign_key: :user_id, dependent: :destroy
+  has_many :event_users, foreign_key: :user_id, dependent: :destroy
   has_many :events, through: :event_users
 
-  has_many :relationships
+  has_many :relationships, foreign_key: :user_id, dependent: :destroy
   has_many :followings, through: :relationships, source: :following
   has_many :passive_relationships, class_name: 'Relationship', foreign_key: 'following_id'
   has_many :follwers, through: :passive_relationships, source: :user

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,36 +1,61 @@
-%h2
-  Edit #{resource_name.to_s.humanize}
-= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
-  = render "devise/shared/error_messages", resource: resource
-  .field
-    = f.label :email
-    %br/
-    = f.email_field :email, autofocus: true, autocomplete: "email"
-  - if devise_mapping.confirmable? && resource.pending_reconfirmation?
-    %div
-      Currently waiting confirmation for: #{resource.unconfirmed_email}
-  .field
-    = f.label :password
-    %i (leave blank if you don't want to change it)
-    %br/
-    = f.password_field :password, autocomplete: "new-password"
-    - if @minimum_password_length
-      %br/
-      %em
-        = @minimum_password_length
-        characters minimum
-  .field
-    = f.label :password_confirmation
-    %br/
-    = f.password_field :password_confirmation, autocomplete: "new-password"
-  .field
-    = f.label :current_password
-    %i (we need your current password to confirm your changes)
-    %br/
-    = f.password_field :current_password, autocomplete: "current-password"
-  .actions
-    = f.submit "Update"
-%h3 Cancel my account
-%p
-  Unhappy? #{button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete}
-= link_to "Back", :back
+= render 'shared/header'
+.custom-form
+  %h2.form-title ユーザー情報の編集
+  .form-container
+    = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
+      = render "devise/shared/error_messages", resource: resource
+      .field
+        = f.label :プロフィール写真
+        .field.image
+          // id "file"で、fileとdivを紐付けクリック時に連動
+          #regitration_img_field{:onclick => "$('#regitration_file').click()"}
+            // 画像があるときは画像を表示する
+            - if @user.image.url.present?
+              = image_tag @user.image.url, class: "user_edit_img"
+            - else
+              = icon('fas', 'camera')
+          = f.file_field :image, class: "regitration_image", style: "display:none;", id: "regitration_file"
+      .field
+        = f.label :ユーザーネーム
+        %br/
+        = f.text_field :name, autofocus: true, autocomplete: "name"
+      .field
+        = f.label :メールアドレス
+        %br/
+        = f.email_field :email, autofocus: true, autocomplete: "email"
+      - if devise_mapping.confirmable? && resource.pending_reconfirmation?
+        %div
+          Currently waiting confirmation for: #{resource.unconfirmed_email}
+      .field
+        = f.label :パスワード
+        %span (パスワードの変更をしない場合は入力不要です)
+        %br/
+        = f.password_field :password, autocomplete: "new-password"
+        - if @minimum_password_length
+          
+          %em
+            = @minimum_password_length
+            文字以上
+      .field
+        = f.label :password_confirmation
+        %br/
+        = f.password_field :password_confirmation, autocomplete: "new-password"
+      .field
+        = f.label :Instagramのアカウント名
+        %br/
+        = f.text_field :url, autocomplete: "url"
+      .field
+        = f.label :プロフィール
+        %br/
+        = f.text_area :profile, autocomplete: "profile"
+      .field
+        = f.label :現在のパスワード
+        %p (ユーザー情報の編集にはパスワードが必要です)
+        %br/
+        = f.password_field :current_password, autocomplete: "current-password"
+      .actions
+        = f.submit "アカウントを更新する", class: "btn"
+      %p.actions
+        #{button_to "アカウントを削除する", registration_path(resource_name), data: { confirm: "本当に削除してもよろしいですか？" }, method: :delete}
+      = link_to "トップページにもどる", root_path, class:"actions"
+= render 'shared/footer'

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -7,11 +7,9 @@
       .field
         = f.label :プロフィール写真
         .field.image
-          -# = icon('fas', 'camera')
-          -# = f.label 'サムネイル（スクリーンショットなど）'
-          -# \// id "file"で、fileとdivを紐付けクリック時に連動
+          // id "file"で、fileとdivを紐付けクリック時に連動
           #regitration_img_field{:onclick => "$('#regitration_file').click()"}
-            -# \// 画像があるときは画像を表示する
+            // 画像があるときは画像を表示する
             - if @user.image.url.present?
               = image_tag(@user.image.url)
             - else
@@ -19,7 +17,6 @@
           = f.file_field :image, class: "regitration_image", style: "display:none;", id: "regitration_file"
 
         %br/
-        -# = f.file_field :image, autofocus: true, autocomplete: "name", placeholder: "田中ユウキ"
       .field
         = f.label :ユーザーネーム
         %br/

--- a/app/views/layouts/_notifications.html.haml
+++ b/app/views/layouts/_notifications.html.haml
@@ -1,0 +1,3 @@
+.notification
+  - flash.each do |key, value|
+    = content_tag :div, value, class: key

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -9,6 +9,7 @@
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   %body
+    = render 'layouts/notifications'
     - unless user_signed_in?
       = link_to 'ゲストユーザーとしてログインして全機能を試す', users_guest_sign_in_path, method: :post, class: 'guest_login'
     = yield

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -6,10 +6,16 @@
       = link_to notifications_path, class: "notifications_link" do
         - if unchecked_notifications.any?
           %span.fa-stack
-            %i.far.fa-bell.fa-lg.fa-stack-2x.bell_icon
+            %i.far.fa-bell.fa-lg.fa-stack-2x
             %i.fas.fa-circle.n-circle.fa-stack-1x
         - else 
-          %i.far.fa-bell.fa-lg.bell_icon
+          %i.far.fa-bell.fa-lg
+          
+        -#   %span.fa-stack
+        -#     %i.far.fa-bell.fa-lg.fa-stack-2x.bell_icon
+        -#     %i.fas.fa-circle.n-circle.fa-stack-1x
+        -# - else 
+        -#   %i.far.fa-bell.fa-lg.bell_icon
       -# = link_to user_path(current_user.id) do
       -#   = icon('fas', 'user')
       = link_to "マイページ", user_path(current_user.id), class: "header_right__my_page"


### PR DESCRIPTION
# WHAT
・ユーザー情報編集画面にimage, name, url, profile用のフォームを追加
・cssを作成し、マークアップを完成
・userを削除時に、userに紐づくevent_userテーブル、relationshipテーブルおレコードも合わせて削除できるようにuser.rb内に以下記述を追加
```
foreign_key : :user_id , dependent: :destroy
```

# WHY
・編集できないカラムが存在していたため
・UXを上げるため
・アソシエーションの問題で、ユーザー情報編集・削除時にエラーが発生する状態になっていたため