### PR TITLE
[WIP]イベント詳細ページにコメント機能を実装

### DIFF
--- a/app/assets/javascripts/comments.js
+++ b/app/assets/javascripts/comments.js
@@ -1,0 +1,2 @@
+// Place all the behaviors and hooks related to the matching controller here.
+// All this logic will automatically be available in application.js.

--- a/app/assets/stylesheets/_reset.scss
+++ b/app/assets/stylesheets/_reset.scss
@@ -46,6 +46,8 @@ th,
 td {
   margin:0;
   padding:0;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 table {
   border-collapse:collapse;

--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the comments controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/events_show.scss
+++ b/app/assets/stylesheets/events_show.scss
@@ -102,12 +102,80 @@
       width: 93%;
       margin: 0 auto;
     }
-    .user_content_title {
+    .user_content_title,
+    .comment_content_title {
       font-size: 1rem;
       font-weight: bold;
       margin: 0.3rem 0;
+      border-bottom: 1px solid #eee;
       @media screen and (min-width:1024px) {
       font-size: 1rem;
       }
     }
+    .comment_form {
+      width: 100%;
+      #comment_text {
+        width: 100%;
+        margin: 0 auto;
+      }
+      input {
+        appearance: none;
+        border: none;
+        font-weight: bold;
+        font-size: 1rem;
+        // border: 2px solid #222;
+        // border-radius: 0.5rem;
+        padding: 0.5rem;
+        display: block;
+        text-align: center;
+        width: 100%;
+        margin: 0 auto;
+      }
+      &__content {
+        width: 100%;
+        display: flex;
+        margin-top: 0.8rem;
+        position: relative;
+        .comment_links {
+          text-decoration: none;
+        }
+        .comment_right {
+          padding-left: 1rem;
+          word-wrap: break-word;
+          width: 100%;
+        }
+          &--img {
+            height: 50px;
+            width: 50px;
+            border-radius: 50%;
+            object-fit: cover;
+            display: inline-block;
+          }
+          &--name {
+            text-decoration: none;
+            color: #222;
+            font-weight: bold;
+            font-size: 0.6rem;
+          }
+          &--text {
+            font-size: 0.6rem;
+            max-width: 85%;
+          }
+          .comment_delete {
+            &__link {
+              position: absolute;
+              right: 0.5rem;
+              bottom: 0.5rem;
+              font-size: 0.6rem;
+              text-decoration: none;
+              color: #999;
+              min-width: 2rem;
+              display: block;
+            }
+          }
+        }
+
+      }
+        
+    
 }

--- a/app/assets/stylesheets/users_show.scss
+++ b/app/assets/stylesheets/users_show.scss
@@ -125,7 +125,7 @@
       border-top: 1px solid #ccc;
       .user_tabs {
         display: flex;
-        justify-content: center;
+        justify-content: space-evenly;
         margin-bottom: 1rem;
         &__item {
           padding: 0.5rem;

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,18 @@
+class CommentsController < ApplicationController
+
+  def create
+    Comment.create(comment_params)
+    redirect_to event_path(params[:event_id]), notice: "コメントを投稿しました"
+  end
+
+  def destroy
+    @comment = Comment.find(params[:id])
+    @comment.destroy
+    redirect_to event_path(params[:event_id]), notice: "コメントを削除しました"
+  end
+
+  private
+  def comment_params
+    params.require(:comment).permit(:text).merge(user_id: current_user.id, event_id: params[:event_id])
+  end
+end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -21,6 +21,8 @@ class EventsController < ApplicationController
   def show
     @users = @event.users
     @owner = User.find_by(id: @event.owner)
+    @comment = Comment.new
+    @comments = @event.comments.includes(:user).order(created_at: :desc)
     if user_signed_in?
       @event_user = EventUser.where(event_id: @event.id, user_id: current_user.id)[0]
     end

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,0 +1,2 @@
+module CommentsHelper
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,4 @@
+class Comment < ApplicationRecord
+  belongs_to :event
+  belongs_to :user
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,7 @@
 class Event < ApplicationRecord
   has_many :event_users, foreign_key: :event_id, dependent: :destroy
   has_many :users, through: :event_users
+  has_many :comments, dependent: :destroy
   
   mount_uploader :image, ImageUploader
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,8 @@ class User < ApplicationRecord
   has_many :messages
   has_many :room_users, foreign_key: :user_id, dependent: :destroy
   has_many :rooms, through: :room_users
+  
+  has_many :comments, dependent: :destroy
 
   has_many :active_notifications, class_name: 'Notification', foreign_key: 'visitor_id', dependent: :destroy
   has_many :passive_notifications, class_name: 'Notification', foreign_key: 'visited_id', dependent: :destroy

--- a/app/views/events/new.html.haml
+++ b/app/views/events/new.html.haml
@@ -6,19 +6,15 @@
       .field
         = f.label :イメージ写真
         .field.image
-          -# = icon('fas', 'camera')
-          -# = f.label 'サムネイル（スクリーンショットなど）'
-          -# \// id "file"で、fileとdivを紐付けクリック時に連動
+          // id "file"で、fileとdivを紐付けクリック時に連動
           #img_field{:onclick => "$('#file').click()"}
-            -# \// 画像があるときは画像を表示する
+            // 画像があるときは画像を表示する
             - if @event.image.url.present?
               = image_tag(@event.image.url)
             - else
               = icon('fas', 'camera')
-              
-              -# %i.fas.fa-image
-              -# %i.fas.fa-file-upload.add
-            -# \// id "file"をつけ、「display:none;」で隠す
+
+          // id "file"をつけ、「display:none;」で隠す
           = f.file_field :image, class: "image", style: "display:none;", id: "file"
 
       .field

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -42,18 +42,22 @@
       - elsif user_signed_in?
         = link_to "参加をやめる", unjoin_event_path(@event.id), method: :delete, class: "done_btn"
       - else
-        = link_to "イベントに参加する場合はログインをしてください", user_session_path, class: "join_btn"
+        = link_to "イベントに参加にはログインが必要です", user_session_path, class: "join_btn"
   .event_info__middle
-  .event_info__lower
-    .user_content_title 参加予定のメンバー
-    .cards_box
+
+  .user_info__lower
+    %ul.user_tabs
+      %li.user_tabs__item.active 参加予定のメンバー
+      %li.user_tabs__item コメント
+
+    .user_cards_box.show
       - @users.each do |user|
         = link_to user_path(user), class: "user_link" do
           .user_card
             .user_card__icon
               = image_tag user.image.url, class: "user_card__icon--content"
             .user_card__name
-              = user.name.truncate(12)
+              = user.name.truncate(8)
             .user_card__request
               - if user_signed_in?
                 - if user.id == current_user.id
@@ -61,4 +65,26 @@
                 - else
                   = link_to "リクエスト", "#", class: "user_card__request--btn"
 
+    .user_cards_box
+      - if current_user
+        .comment_form
+          = form_with(model: [@event, @comment], local: true) do |f|
+            = f.text_area :text, placeholder: "コメントする", rows: "2"
+            = f.submit "投稿する"
+        - if @comments
+          - @comments.each do |comment|
+            .comment_form__content
+              .comment_left
+                = link_to user_path(comment.user_id), class: "comment_links" do
+                  = image_tag comment.user.image.url, class: "comment_form__content--img"
+              .comment_right
+                %strong
+                  = link_to comment.user.name, user_path(comment.user_id), class: "comment_form__content--name"
+                %p.comment_form__content--text
+                  = comment.text
+              .comment_delete
+                - if current_user == comment.user
+                  = link_to "削除", event_comment_path(comment.event.id, comment.id), method: :delete, class: "comment_delete__link"
+      - else
+        コメントの投稿にはログインが必要です
 = render 'shared/footer'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   root "events#index"
   
   resources :events do
+    resources :comments, only: [:create, :destroy]
     member do
       post :join
       delete :unjoin

--- a/db/migrate/20200303135346_create_comments.rb
+++ b/db/migrate/20200303135346_create_comments.rb
@@ -1,0 +1,10 @@
+class CreateComments < ActiveRecord::Migration[5.2]
+  def change
+    create_table :comments do |t|
+      t.integer :user_id
+      t.integer :event_id
+      t.text :text
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_02_040735) do
+ActiveRecord::Schema.define(version: 2020_03_03_135346) do
+
+  create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "event_id"
+    t.text "text"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "event_users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "event_id"

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CommentsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CommentTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# WHAT
・イベント詳細ページにコメント機能を実装
・「参加予定のメンバー」と「コメント」を切り替えるタブ機能を実装
※非同期化は未実装

# WHY
・ポートフォリオのクオリティ向上のため

[![Image from Gyazo](https://i.gyazo.com/d3ce532725f0b68ef05fa551fa619693.gif)](https://gyazo.com/d3ce532725f0b68ef05fa551fa619693)