### PR TITLE
通知一覧ページのバグ改修

### DIFF
--- a/app/views/notifications/index.html.haml
+++ b/app/views/notifications/index.html.haml
@@ -11,7 +11,10 @@
         .notifications__left
           %span.notifications__img
             = link_to user_path(visitor) do
-              = image_tag visitor.image.url, class:"notifications__img--content"
+              - if visitor.email == 'guest@example.com'
+                = image_tag "user_test_login.jpg", class:"notifications__img--content"
+              - else
+                = image_tag visitor.image.url, class:"notifications__img--content"
           %span.notifications__text
             %p
               = link_to visitor.name, user_path(visitor), class: "notifications__text--content"


### PR DESCRIPTION
# WHAT
・通知一覧ページのuser.imageの表示にて、ゲストユーザーとそうでない場合での条件分岐を行った

# WHY
・ゲストユーザーからの通知があった場合に、画像が表示できずエラーが発生していたため