### PR TITLE
リクエスト解除時の確認ダイアログを実装

### DIFF
--- a/app/assets/javascripts/confirm.js
+++ b/app/assets/javascripts/confirm.js
@@ -1,0 +1,8 @@
+function MoveCheck() {
+  if( confirm("マッチング中のへのリクエストを解除すると、チャットメッセージが全て削除されます。本当にリクエスト解除しますか？") ) {
+      window.location.href = "https://www.nishishi.com/";
+  }
+  else {
+      alert("リクエストの解除をやめました。");
+  }
+}

--- a/app/assets/stylesheets/_reset.scss
+++ b/app/assets/stylesheets/_reset.scss
@@ -114,7 +114,6 @@ select {
   font-family:inherit;
   font-size:inherit;
   padding: 0.5rem 0.5rem;
-  -webkit-appearance: none;
 }
 /*to enable resizing for IE*/
 input,

--- a/app/assets/stylesheets/notifications_index.scss
+++ b/app/assets/stylesheets/notifications_index.scss
@@ -23,7 +23,7 @@
   }
   &__text {
     position: absolute;
-    left: 70px;
+    left: 80px;
     top: 30%;
     font-size: 0.5rem;
     @media screen and (min-width:425px) and (max-width:1024px){

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -7,9 +7,9 @@ class RelationshipsController < ApplicationController
     user.create_notification_follow!(current_user)
     
     if following.save
-      flash[:success] = 'ユーザーをフォローしました'
+      flash[:notice] = 'リクエストを送信しました'
     else
-      flash.now[:alert] = 'ユーザーのフォローに失敗しました'
+      flash[:alert] = 'リクエストに失敗しました'
     end
     redirect_to user
   end
@@ -18,9 +18,9 @@ class RelationshipsController < ApplicationController
     user = User.find(params[:relationship][:following_id])
     following = current_user.unfollow(user)
     if following.destroy
-      flash[:success] = 'ユーザーのフォローを解除しました'
+      flash[:notice] = 'リクエストを解除しました'
     else
-      flash.now[:alert] = 'ユーザーのフォロー解除に失敗しました'
+      flash.now[:alert] = 'リクエストの解除に失敗しました'
     end
     redirect_to user
   end

--- a/app/views/shared/_request_btn.html.haml
+++ b/app/views/shared/_request_btn.html.haml
@@ -2,7 +2,8 @@
   - if user_signed_in? && current_user.following?(@user)
     = form_for(current_user.relationships.find_by(following_id: @user.id), html: { method: :delete }) do |f| # 自分のrelationshipの中に、@userがいるかどうか？
       = f.hidden_field :following_id, value: @user.id
-      = f.submit 'リクエスト済み', class: 'follow_done_btn'
+      = f.submit 'リクエスト済み', data:{ confirm: "リクエストを解除すると、#{@user.name}さんとのメッセージは全て削除されます。\n本当にリクエストを解除しますか？", cancel: '解除しない', commit: 'リクエストを解除する'}, class: 'follow_done_btn'
+
   - else
     = form_for(current_user.relationships.build) do |f|
       = f.hidden_field :following_id, value: @user.id


### PR DESCRIPTION
# WHAT
・マッチング中のユーザーのリクエストを解除しようとすると、「本当にしていいですか？」という確認ダイアログが表示されるように実装

# WHY
・マッチング中のユーザーのリクエストを解除すると、紐づいているroomが消える仕様のため、ユーザーに対しても事前に確認をさせる必要があったため

[![Image from Gyazo](https://i.gyazo.com/8753f4fd3d5998cf898c2e7200a2dbbb.gif)](https://gyazo.com/8753f4fd3d5998cf898c2e7200a2dbbb)