### PR TITLE
ユーザー削除時に主宰イベントも削除するよう仕様変更

### DIFF
--- a/app/assets/javascripts/events.js
+++ b/app/assets/javascripts/events.js
@@ -35,8 +35,9 @@ $(function() {
   function addNoEvent() {
     let html = `
       <div class="no_event">
-        <i class="fas fa-exclamation-triangle"></i>
+        <i class="fas fa-exclamation-triangle">
           イベントが見つかりません
+        </i>
       </div>
     `
     $("#event_search_result").append(html);

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -11,6 +11,15 @@ class Users::RegistrationsController < Devise::RegistrationsController
     end
   end
 
+  def destroy
+    # user削除時にそのユーザーがownerのeventも合わせて削除する処理
+    events = Event.where(owner: @user.id)
+    events.each do |event|
+      event.destroy
+    end
+    @user.destroy
+    redirect_to root_path, notice: 'アカウントを削除しました。メンバーをお探しの際は、また是非ご利用ください！'
+  end
   # GET /resource/sign_up
   # def new
   #   super

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -6,7 +6,7 @@ class Users::SessionsController < Devise::SessionsController
   def new_guest
     user = User.guest
     sign_in user
-    redirect_to root_path, notice: "ゲストログインしました"
+    redirect_to root_path, notice: "ゲストユーザーとしてログインしました"
   end
 
   # GET /resource/sign_in

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,7 +24,7 @@ class User < ApplicationRecord
     find_or_create_by!({email: 'guest@example.com'}) do |user|
       user.password = SecureRandom.urlsafe_base64
       user.name = "ゲストユーザー"
-      user.profile = SecureRandom.urlsafe_base64      
+      user.profile = "ゲストユーザーです。\nこのユーザーのプロフィールの編集及び削除機能は利用不可としております。\n予めご了承くださいませ。"
     end
   end
   

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -31,7 +31,10 @@
             %tr
               %th 主催者
               %td
-                = link_to @owner.name, user_path(@owner.id), class: "owner_link"
+                - if @owner == nil
+                  %i.fas.fa-exclamation-triangle 削除済みのユーザーです
+                - else
+                  = link_to @owner.name, user_path(@owner.id), class: "owner_link"
 
     - if user_signed_in? && current_user.id == @event.owner
       = link_to "イベントを編集する", edit_event_path(@event.id), class: "admin_btn"
@@ -55,7 +58,10 @@
         = link_to user_path(user.id), class: "user_link" do
           .user_card
             .user_card__icon
-              = image_tag user.image.url, class: "user_card__icon--content"
+              - if user.email == "guest@example.com"
+                = image_tag "user_test_login.jpg", class: "user_card__icon--content"
+              - else
+                = image_tag user.image.url, class: "user_card__icon--content"
             .user_card__name
               = user.name.truncate(8)
             .user_card__request

--- a/app/views/notifications/index.html.haml
+++ b/app/views/notifications/index.html.haml
@@ -24,6 +24,5 @@
         .notifications__right
           = time_ago_in_words(notification.created_at).upcase
   - else
-    -# .form_notifications
     %p.notifications__nothing 通知はありません
 = render 'shared/footer'

--- a/app/views/rooms/show.html.haml
+++ b/app/views/rooms/show.html.haml
@@ -19,6 +19,5 @@
       = f.hidden_field :room_id, value: @room.id
       = f.hidden_field :user_id, value: @self.id
       = f.text_field :content, placeholder: "Aa", class: 'chat_form'
-      -# = f.submit '送信', class: 'chat_send fas camera'
       = button_tag type: 'submit', class: "chat_send" do
         = icon('fas', 'paper-plane')

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -91,7 +91,7 @@ ja:
     registrations:
       destroyed: アカウントを削除しました。またのご利用をお待ちしております。
       edit:
-        are_you_sure: 本当によろしいですか?
+        are_you_sure: "あなたが作成したイベント、メッセージ、マッチングが全て削除されます。\n本当によろしいですか?"
         cancel_my_account: アカウント削除
         currently_waiting_confirmation_for_email: "%{email} の確認待ち"
         leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません


### PR DESCRIPTION
# WHAT
・アカウント削除時のコントローラー処理に、そのユーザーがownerとなっているイベントも全て削除する処理を実装
・ownerはeventテーブルのカラムとしており、アソシエーションによって削除することができなかったためコントローラーの処理で対応

# WHY
・削除済みオーナーが主宰のイベントが残っているとUXが悪くなるから、またエラーが発生するため