### PR TITLE
各モデルの文字数バリデーション実装

### DIFF
--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -31,6 +31,7 @@ header {
       border-radius: 5px;
       cursor: pointer;
       display: none;
+      line-height: 36px;
       @media screen and (min-width: 426px) {
         padding: 10px;
         display: inline;
@@ -47,6 +48,7 @@ header {
       }
     }
     &__sign_in {
+      line-height: 36px;
       text-decoration: none;
       color: #222;
       font-weight: bold;
@@ -66,6 +68,7 @@ header {
       border: 1.5px solid #212529;
       padding: 4px 5px;
       border-radius: 5px;
+      line-height: 36px;
       cursor: pointer;
       @media screen and (min-width:768px) {
         font-size: 0.8rem;

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -5,15 +5,19 @@ class CommentsController < ApplicationController
     if @comment.save
       redirect_to event_path(params[:event_id]), notice: "コメントを投稿しました"
     else
-      flash[:alert] = "空欄のコメントは入力できません"
+      flash[:alert] = "文字数を確認してください"
       redirect_to event_path(params[:event_id])
     end
   end
 
   def destroy
     @comment = Comment.find(params[:id])
-    @comment.destroy
-    redirect_to event_path(params[:event_id]), notice: "コメントを削除しました"
+    if @comment.destroy
+      redirect_to event_path(params[:event_id]), notice: "コメントを削除しました"
+    else
+      flash[:alert] = "コメントの削除に失敗しました"
+      redirect_to event_path(params[:event_id])
+    end
   end
 
   private

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -5,7 +5,7 @@ class MessagesController < ApplicationController
     if message.save
       redirect_to room_path(params[:room_id])
     else
-      flash[:alert] = "空のメッセージは送信できません"
+      flash[:alert] = "文字数を確認してください。"
       redirect_to room_path(params[:room_id])
     end
   end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -2,5 +2,5 @@ class Comment < ApplicationRecord
   belongs_to :event
   belongs_to :user
 
-  validates :text, presence: true
+  validates :text, presence: true, length: { in: 1..255 }
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -5,7 +5,6 @@ class Event < ApplicationRecord
   
   validates :name, :date, :image, :place, :open_time, :end_time, :owner, :description, presence: true
   validates :name, length: { in: 1..75 }
-  validates :description, length: { in: 1..255 }
   
   mount_uploader :image, ImageUploader
 

--- a/app/views/notifications/index.html.haml
+++ b/app/views/notifications/index.html.haml
@@ -11,10 +11,13 @@
         .notifications__left
           %span.notifications__img
             = link_to user_path(visitor) do
-              - if visitor.email == 'guest@example.com'
-                = image_tag "user_test_login.jpg", class:"notifications__img--content"
+              - if visitor.image.present?
+                - if visitor.email == 'guest@example.com'
+                  = image_tag "user_test_login.jpg", class:"notifications__img--content"
+                - else
+                  = image_tag visitor.image.url, class:"notifications__img--content"
               - else
-                = image_tag visitor.image.url, class:"notifications__img--content"
+                = image_tag "user_test_login.jpg", class:"notifications__img--content"
           %span.notifications__text
             %p
               = link_to visitor.name, user_path(visitor), class: "notifications__text--content"

--- a/db/migrate/20200307151814_change_datatype_description_of_events.rb
+++ b/db/migrate/20200307151814_change_datatype_description_of_events.rb
@@ -1,0 +1,5 @@
+class ChangeDatatypeDescriptionOfEvents < ActiveRecord::Migration[5.2]
+  def change
+    change_column :events, :description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_03_135346) do
+ActiveRecord::Schema.define(version: 2020_03_07_151814) do
 
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id"
@@ -41,7 +41,7 @@ ActiveRecord::Schema.define(version: 2020_03_03_135346) do
     t.integer "owner", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "description", null: false
+    t.text "description", null: false
   end
 
   create_table "messages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|


### PR DESCRIPTION
# WHAT
・eventモデルのdescriptionは255文字以上の入力を想定して、string型からtext型に変更

# WHY
・テストユーザーから、255文字では短いとの声があったから