### PR TITLE
想定外のURLに直接アクセスされたときのエラーハンドリング

### DIFF
--- a/app/assets/stylesheets/events_show.scss
+++ b/app/assets/stylesheets/events_show.scss
@@ -68,7 +68,7 @@
       font-weight: bold;
       font-size: 1rem;
       border: 2px solid #a10000;
-      border-radius: 0.5rem;
+      border-radius: 1.5rem;
       padding: 0.5rem;
       margin: 1rem auto;
       display: block;

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -11,7 +11,11 @@ class EventsController < ApplicationController
   end
 
   def new
-    @event = Event.new
+    if user_signed_in?
+      @event = Event.new
+    else
+      redirect_to new_user_session_path, alert: "イベントの作成にはログインが必要です"
+    end
   end
 
   def create
@@ -35,6 +39,11 @@ class EventsController < ApplicationController
   end
   
   def edit
+    if user_signed_in?
+      redirect_to root_path, alert: "イベントオーナー以外はイベントの編集ができません" unless @event.owner == current_user.id
+    else
+      redirect_to new_user_session_path, alert: "イベントの編集にはログインが必要です"
+    end
   end
   
   def update

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,8 +1,12 @@
 class NotificationsController < ApplicationController
   def index
-    @notifications = current_user.passive_notifications
-    @notifications.where(checked: false).each do |notification|
-      notification.update_attributes(checked: true)
+    if user_signed_in?
+      @notifications = current_user.passive_notifications
+      @notifications.where(checked: false).each do |notification|
+        notification.update_attributes(checked: true)
+      end
+    else
+      redirect_to root_path, alert: "リクエスト通知の閲覧にはログインが必要です"
     end
   end
 end

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -14,10 +14,15 @@ class RoomsController < ApplicationController
   end
 
   def show
-    @room = Room.find(params[:id])
-    @self = @room.users.find_by(id: current_user.id)
-    @other_user = @room.users.where.not(id: current_user.id)[0]
-    @messages = @room.messages
+    if user_signed_in?
+      @room = Room.find(params[:id])
+      redirect_to root_path, alert: "あなたの所属していないチャットルームの閲覧はできません" unless @room.users.include?(current_user)
+      @self = @room.users.find_by(id: current_user.id)
+      @other_user = @room.users.where.not(id: current_user.id)[0]
+      @messages = @room.messages
+    else
+      redirect_to new_user_session_path, alert: "チャット機能の利用にはログインが必要です"
+    end
   end
 
   

--- a/app/views/events/new.html.haml
+++ b/app/views/events/new.html.haml
@@ -45,7 +45,6 @@
         = f.label :詳細
         %br/
         = f.text_area :description, autofocus: true, autocomplete: "descroption", placeholder: "初心者からでも気軽に参加できるダブルダッチ1on1のバトルイベントです。\nターナーは運営側で用意しますので、体一つで挑戦できます。音を感じて楽しんでいってください！！"
-        (255文字以内)
       .actions
         = f.submit "イベントを作成する", class: "btn"
 = render 'shared/footer'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
   
   resources :users, only: [:show]
   resources :relationships, only: [:create, :destroy]
-  resources :rooms, only: [:index, :new, :create, :show, :update]
+  resources :rooms, only: [:create, :show, :update]
   resources :messages, only: [:index, :create]
   resources :notifications, only: [:index]
 end


### PR DESCRIPTION
# WHAT
・owner以外がevents#editにアクセスしようとすると、root_pathにリダイレクトされるよう実装
・未ログイン状態でevents#newにアクセスしようとすると、root_pathにリダイレクトされるよう実装
・自分の所属していないroomにアクセスしようとすると、root_pathにリダイレクトされるよう実装
・未ログイン状態でnotifications#indexにアクセスしようとするとroot_pathにリダイレクトさせるよう実装

# WHY
・悪意のあるアクセスを防ぐため