### PR TITLE
終了済みイベントの表示方法を修正

### DIFF
--- a/app/assets/stylesheets/events_show.scss
+++ b/app/assets/stylesheets/events_show.scss
@@ -11,11 +11,23 @@
   }
   .event_icon {
     text-align: center;
+    position: relative;
+    max-height: 400px;
     &__content {
       width: 100%;
       max-height: 400px;
       border-radius: 0.25rem;
       object-fit: cover;
+    }
+    .event_end_message {
+      color: #fff;
+      background: rgba(0,0,0,.6);
+      position: absolute;
+      width: 100%;
+      height: calc(100% - 10rem);
+      padding: 5rem 0;
+      font-weight: bold;
+      border-radius: 0.25rem;
     }
   }
   table {

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -2,9 +2,10 @@ class EventsController < ApplicationController
 
   before_action :set_event, only: [:show, :edit, :update, :join, :unjoin, :destroy]
   before_action :move_to_index, only: [:new, :edit]
+  require "date"
 
   def index
-    @events = Event.all.order(date: :asc).page(params[:page]).per(6)
+    @events = Event.where("events.date > ?", DateTime.now).order(date: :asc).page(params[:page]).per(6)
     @new_events = Event.all.order(created_at: :asc).page(params[:page]).per(6)
     @search_events = Event.search(params[:keyword])
     respond_to do |format|

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -30,7 +30,8 @@
   %ul.skill-list.jscroll#event_search_result
     .cards_box#event_index
       = render 'event_cards'
-    
+  
+  -# イベント作成ボタン
   = link_to new_event_path , class: "event_post_path" do
     .event_post
       .event_post__btn

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -2,8 +2,13 @@
 .event_info
   .event_info__upper
     .event_icon
-      = image_tag @event.image.url, class: "event_icon__content"
-    
+      - if @event.date < DateTime.now
+        %p.event_end_message
+          このイベントは終了しました
+        = image_tag @event.image.url, class: "event_icon__content"
+      -else
+        = image_tag @event.image.url, class: "event_icon__content"
+
     .event_info__text_box
       .event_info__text_box--name
         = @event.name

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,6 +1,6 @@
 # config valid only for current version of Capistrano
 # capistranoのバージョンを記載。固定のバージョンを利用し続け、バージョン変更によるトラブルを防止する
-lock '3.12.1'
+lock '3.12.0'
 
 # Capistranoのログの表示に利用する
 set :application, 'st-connect'

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -7,7 +7,7 @@
 # server "example.com", user: "deploy", roles: %w{app web}, other_property: :other_value
 # server "db.example.com", user: "deploy", roles: %w{db}
 server '54.178.158.206', user: 'ec2-user', roles: %w[app db web]
-server '54.249.15.67', user: 'ec2-user', roles: %w{app db web}
+# server '54.249.15.67', user: 'ec2-user', roles: %w{app db web}
 
 # role-based syntax
 # ==================


### PR DESCRIPTION
# WHAT
・終了済みイベントは一覧表示には非表示
・検索時に表示
・イベント詳細ページに遷移した時に、「このイベントは終了しています」の表示を追加

# WHY
・UX向上のため

[![Image from Gyazo](https://i.gyazo.com/decbc07ec7d7a49dc38a4a662c47ec0b.png)](https://gyazo.com/decbc07ec7d7a49dc38a4a662c47ec0b)